### PR TITLE
Bugfix key ratios 500 http

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tidyquant
 Type: Package
 Title: Tidy Quantitative Financial Analysis
-Version: 0.3.0.9050
+Version: 0.3.0.9060
 Date: 2017-01-28
 Authors@R: person("Matt", "Dancho", email = "mdancho@gmail.com", 
     role = c("aut", "cre"))
@@ -41,7 +41,8 @@ Imports:
     timeSeries (>= 3022.101.2),
     tseries (>= 0.10-37),
     xml2 (>= 1.1.0),
-    zoo (>= 1.7-14)
+    zoo (>= 1.7-14),
+    httr (>= 1.2.1)
 Suggests:
     knitr,
     rmarkdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,9 +3,9 @@
 * Documentation:
     * Split introduction into four separate vignettes, which improves flow and enables readers to more easily get to needed documentation. Now five docs total covering the primary needs of `tidyquant` users!
 * New data:
-    * Issue #11: Part 1. Fix instability with `get = key.ratios` failing with HTTP 500 error on download. Use httr RETRY in case of failure.
     * `tq_exchange()` gets the stock list for NASDAQ, NYSE, and AMEX exchanges. Use `tq_exchange_options()` to exchange options.
 * Fixes:
+    * Issue #11: Part 1. Fix instability with `get = key.ratios` failing with HTTP 500 error on download. Use httr RETRY in case of failure.
     * Fixed issue with `get = "key.ratios"` where stocks listed on AMEX exchange were not able to return key ratios.
     * Issue #9: Fix problem with `get = "key.stats"` where NA's in multiple `x` (e.g. `c("AAPL", "GOOG")`) cause call to fail during coercion. 
     * Issue #8, Part 2: Enable compound gets (e.g. `tq_get("AAPL", get = c("stock.prices", "financials"))`).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
-# tidyquant 0.3.0.9050 - Development Version
+# tidyquant 0.3.0.9060 - Development Version
 
 * Documentation:
     * Split introduction into four separate vignettes, which improves flow and enables readers to more easily get to needed documentation. Now five docs total covering the primary needs of `tidyquant` users!
 * New data:
+    * Issue #11: Part 1. Fix instability with `get = key.ratios` failing with HTTP 500 error on download. Use httr RETRY in case of failure.
     * `tq_exchange()` gets the stock list for NASDAQ, NYSE, and AMEX exchanges. Use `tq_exchange_options()` to exchange options.
 * Fixes:
     * Fixed issue with `get = "key.ratios"` where stocks listed on AMEX exchange were not able to return key ratios.

--- a/R/tq_get.R
+++ b/R/tq_get.R
@@ -397,23 +397,21 @@ tq_get_util_2 <- function(x, get, complete_cases, map, ...) {
     tryCatch({
 
         # Download file
-        tmp <- tempfile()
         stock_exchange <- c("XNAS", "XNYS", "XASE") # mornginstar gets from various exchanges
         url_base_1 <- 'http://financials.morningstar.com/finan/ajax/exportKR2CSV.html?&callback=?&t='
         url_base_2 <- '&region=usa&culture=en-US&cur=&order=asc'
-        # Two URLs to try
+        # Three URLs to try
         url <- paste0(url_base_1, stock_exchange, ":", x, url_base_2)
 
         # Try various stock exchanges
-        try_backoff({
-            download.file(url[1], destfile = tmp, quiet = TRUE)
-            if (length(readLines(tmp)) == 0) {
-                download.file(url[2], destfile = tmp, quiet = TRUE)
-                if (length(readLines(tmp)) == 0) {
-                    download.file(url[3], destfile = tmp, quiet = TRUE)
-                }
+        for(i in 1:3) {
+            text <- httr::RETRY("GET", url[i], times = 5) %>%
+                httr::content()
+
+            if(!is.null(text)) {
+                break
             }
-        })
+        }
 
         # Setup Tibble Part 1
         key_ratios_1 <- tibble::tibble(
@@ -440,11 +438,13 @@ tq_get_util_2 <- function(x, get, complete_cases, map, ...) {
 
         # Read lines
         skip_rows <- c(1:2, 19:21, 31:32, 41:44, 49, 54, 59, 64:66, 72:74, 95:96, 101:103)
-        text <- readr::read_lines(tmp)[-skip_rows]
-
-        # Unlink tmp
-        unlink(tmp)
-
+        
+        text <- text %>%
+            xml2::as_list() %>%
+            unlist() %>%
+            readr::read_lines() %>%
+            .[-skip_rows]
+        
         # Parse text
         key_ratios_2 <-
             suppressMessages(
@@ -701,24 +701,4 @@ validate_compound_gets <- function(get) {
     if (!all(get %in% compound_get_options)) {
         stop("Get options for compound get are not valid.")
     }
-}
-             
-# Ensure 500 HTTP error avoided -----
-try_backoff <- function(expr, silent = FALSE, max_attempts = 10, verbose = FALSE) {
-    for (attempt_i in seq_len(max_attempts)) {
-        results <- try(expr = expr, silent = silent)
-        if (inherits(results, "try-error")) {
-            backoff <- runif(n = 1, min = 0, max = 2^attempt_i - 1)
-            if (verbose) {
-                message("Backing off for ", backoff, " seconds.")
-            }
-            Sys.sleep(backoff)
-        } else {
-            if (verbose) {
-                message("Succeeded after ", attempt_i, " attempts.")
-            }
-            break
-        }
-    }
-    results
 }


### PR DESCRIPTION
Fix 500 HTTP error when using `get = key.ratios`. Use `httr` and `RETRY()` to throttle the downloads and retry on failure. Also, no reliance on creating a temp file.